### PR TITLE
Additional time format

### DIFF
--- a/encoding/json/timestamp.go
+++ b/encoding/json/timestamp.go
@@ -2,19 +2,33 @@ package json
 
 import (
 	"strconv"
+	"strings"
 	"time"
 )
+
+const variousDate = "2006-01-02 15:04:05 -0700"
 
 type Timestamp struct {
 	time.Time
 }
 
 func (t *Timestamp) UnmarshalJSON(b []byte) error {
-	if string(b) == `""` || string(b) == "null" {
+	s := string(b)
+
+	if s == `""` || s == "null" {
 		return nil
 	}
 
-	if n, err := strconv.ParseInt(string(b), 10, 64); err == nil {
+	if strings.Contains(s, " ") {
+		if c, err := strconv.Unquote(s); err == nil {
+			if v, err := time.Parse(variousDate, c); err == nil {
+				t.Time = v
+				return nil
+			}
+		}
+	}
+
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
 		t.Time = time.Unix(n, 0)
 		return nil
 	}

--- a/encoding/json/timestamp_test.go
+++ b/encoding/json/timestamp_test.go
@@ -13,6 +13,10 @@ func TestTimestamp(t *testing.T) {
 	testTimestamp(t, []byte("1490318752"))
 }
 
+func TestTimestamp_format1(t *testing.T) {
+	testTimestamp(t, []byte(`"2017-03-24 08:25:52 +0700"`))
+}
+
 func TestTimestamp_fallback(t *testing.T) {
 	testTimestamp(t, []byte(`"2017-03-24T08:25:52+07:00"`))
 }


### PR DESCRIPTION
added support for time format `2006-01-02 15:04:05 -0700` in addition to unix timestamp.