### PR TITLE
custom marshaler and unmarshaler for type alias json.Number

### DIFF
--- a/encoding/json/number.go
+++ b/encoding/json/number.go
@@ -1,0 +1,40 @@
+package json
+
+import (
+	builtin_json "encoding/json"
+	"strconv"
+)
+
+type Number builtin_json.Number
+
+func (n Number) String() string { return string(n) }
+
+// Float64 returns the number as a float64.
+func (n Number) Float64() (float64, error) {
+	return strconv.ParseFloat(string(n), 64)
+}
+
+// Int64 returns the number as an int64.
+func (n Number) Int64() (int64, error) {
+	return strconv.ParseInt(string(n), 10, 64)
+}
+
+func (v *Number) UnmarshalJSON(b []byte) error {
+	strB := string(b)
+	if strB == "" || strB == "null" {
+		return nil
+	}
+
+	s := new(builtin_json.Number)
+	err := builtin_json.Unmarshal(b, s)
+	if err != nil {
+		return err
+	}
+
+	*v = Number(*s)
+	return nil
+}
+
+func (v *Number) MarshalJSON() ([]byte, error) {
+	return []byte(v.String()), nil
+}

--- a/encoding/json/number_test.go
+++ b/encoding/json/number_test.go
@@ -1,0 +1,91 @@
+package json_test
+
+import (
+	"testing"
+
+	"github.com/bukalapak/ottoman/encoding/json"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNumber_invalid(t *testing.T) {
+	var m json.Number
+
+	x := "lorem"
+	err := m.UnmarshalJSON([]byte(x))
+	assert.NotNil(t, err)
+
+	x = "1L"
+	err = m.UnmarshalJSON([]byte(x))
+	assert.NotNil(t, err)
+
+	x = "12.1012.01"
+	err = m.UnmarshalJSON([]byte(x))
+	assert.NotNil(t, err)
+}
+
+func TestNumber_empty_string(t *testing.T) {
+	var m json.Number
+
+	x := ""
+	err := m.UnmarshalJSON([]byte(x))
+	assert.Nil(t, err)
+	assert.Equal(t, "", m.String())
+
+	_, err = m.Int64()
+	assert.NotNil(t, err)
+
+	b, err := m.MarshalJSON()
+	assert.Nil(t, err)
+	assert.Equal(t, x, string(b))
+
+	x = "null"
+	err = m.UnmarshalJSON([]byte(x))
+	assert.Nil(t, err)
+	assert.Equal(t, "", m.String())
+
+	_, err = m.Int64()
+	assert.Error(t, err)
+
+	b, err = m.MarshalJSON()
+	assert.Nil(t, err)
+	assert.Equal(t, "", string(b))
+
+	err = m.UnmarshalJSON([]byte(nil))
+	assert.Nil(t, err)
+	assert.Equal(t, "", m.String())
+
+	_, err = m.Int64()
+	assert.Error(t, err)
+
+}
+
+func TestNumber_null_string(t *testing.T) {
+	var m json.Number
+
+	x := "null"
+	err := m.UnmarshalJSON([]byte(x))
+	assert.Nil(t, err)
+
+	_, err = m.Int64()
+	assert.Error(t, err)
+
+	b, err := m.MarshalJSON()
+	assert.Nil(t, err)
+	assert.Equal(t, "", string(b))
+}
+
+func TestNumber_number_string(t *testing.T) {
+	var m json.Number
+
+	x := "3"
+	err := m.UnmarshalJSON([]byte(x))
+	assert.Nil(t, err)
+
+	v, err := m.Int64()
+	assert.Nil(t, err)
+	assert.Equal(t, int64(3), v)
+
+	b, err := m.MarshalJSON()
+	assert.Nil(t, err)
+	assert.Equal(t, x, string(b))
+}


### PR DESCRIPTION
We discovered that the unmarshal behavior of json.Number changed. On go1.13, whenever empty string umarshaled into json.Number, there won't be any error. On go1.14, the behavior is return error. See https://go-review.googlesource.com/c/go/+/195045/

Summary of changes: create custom unmarshaller for Number. 