### PR TITLE
custom marshaler and unmarshaler for type alias json.Number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.15.0] - 2021-04-30
+
+### Added
+
+- Add new type `Number` as alias from `json.Number`
+- Add custom marshaler and unmarshaler for type `Number`
+
 ## [1.14.0] - 2021-02-26
 
 ### Updated

--- a/encoding/json/number.go
+++ b/encoding/json/number.go
@@ -3,27 +3,12 @@ package json
 import (
 	"encoding/json"
 	bjson "encoding/json"
-	"strconv"
 )
 
 type Number bjson.Number
 
-// String returns the literal text of the number.
-func (v Number) String() string { return string(v) }
-
-// Float64 returns the number as a float64.
-func (v Number) Float64() (float64, error) {
-	return strconv.ParseFloat(string(v), 64)
-}
-
-// Int64 returns the number as an int64.
-func (v Number) Int64() (int64, error) {
-	return strconv.ParseInt(string(v), 10, 64)
-}
-
 func (v *Number) UnmarshalJSON(b []byte) error {
-	strB := string(b)
-	if strB == `""` || strB == "null" {
+	if string(b) == `""` {
 		*v = Number("")
 		return nil
 	}
@@ -39,18 +24,6 @@ func (v *Number) UnmarshalJSON(b []byte) error {
 }
 
 func (v *Number) MarshalJSON() ([]byte, error) {
-	if v.String() == "" {
-		return json.Marshal(0)
-	}
-
-	i, err := v.Int64()
-	if err != nil {
-		f, err := v.Float64()
-		if err != nil {
-			return nil, err
-		}
-		return json.Marshal(f)
-	}
-
-	return json.Marshal(i)
+	n := bjson.Number(*v)
+	return json.Marshal(n)
 }

--- a/encoding/json/number.go
+++ b/encoding/json/number.go
@@ -2,28 +2,35 @@ package json
 
 import (
 	bjson "encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
 )
 
-type Number struct {
-	bjson.Number
-}
+type Number bjson.Number
 
-func (n Number) String() string { return n.Number.String() }
+// String returns the literal text of the number.
+func (v Number) String() string { return string(v) }
 
 // Float64 returns the number as a float64.
-func (n Number) Float64() (float64, error) {
-	return n.Number.Float64()
+func (v Number) Float64() (float64, error) {
+	return strconv.ParseFloat(string(v), 64)
 }
 
 // Int64 returns the number as an int64.
-func (n Number) Int64() (int64, error) {
-	return n.Number.Int64()
+func (v Number) Int64() (int64, error) {
+	return strconv.ParseInt(string(v), 10, 64)
 }
 
 func (v *Number) UnmarshalJSON(b []byte) error {
-	strB := string(b)
+	strB := strings.Trim(string(b), "\"")
 	if strB == "" || strB == "null" {
+		*v = Number("")
 		return nil
+	}
+
+	if !isValidNumber(strB) {
+		return fmt.Errorf("Invalid number %s for type Number", strB)
 	}
 
 	var s bjson.Number
@@ -32,10 +39,63 @@ func (v *Number) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	v.Number = s
+	*v = Number(s)
 	return nil
 }
 
-func (v *Number) MarshalJSON() ([]byte, error) {
-	return []byte(v.String()), nil
+// isValidNumber reports whether s is a valid JSON number literal. Taken from encoding/json package
+func isValidNumber(s string) bool {
+
+	if s == "" {
+		return false
+	}
+
+	// Optional -
+	if s[0] == '-' {
+		s = s[1:]
+		if s == "" {
+			return false
+		}
+	}
+
+	// Digits
+	switch {
+	default:
+		return false
+
+	case s[0] == '0':
+		s = s[1:]
+
+	case '1' <= s[0] && s[0] <= '9':
+		s = s[1:]
+		for len(s) > 0 && '0' <= s[0] && s[0] <= '9' {
+			s = s[1:]
+		}
+	}
+
+	// . followed by 1 or more digits.
+	if len(s) >= 2 && s[0] == '.' && '0' <= s[1] && s[1] <= '9' {
+		s = s[2:]
+		for len(s) > 0 && '0' <= s[0] && s[0] <= '9' {
+			s = s[1:]
+		}
+	}
+
+	// e or E followed by an optional - or + and
+	// 1 or more digits.
+	if len(s) >= 2 && (s[0] == 'e' || s[0] == 'E') {
+		s = s[1:]
+		if s[0] == '+' || s[0] == '-' {
+			s = s[1:]
+			if s == "" {
+				return false
+			}
+		}
+		for len(s) > 0 && '0' <= s[0] && s[0] <= '9' {
+			s = s[1:]
+		}
+	}
+
+	// Make sure we are at the end.
+	return s == ""
 }

--- a/encoding/json/number.go
+++ b/encoding/json/number.go
@@ -23,7 +23,7 @@ func (v *Number) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (v *Number) MarshalJSON() ([]byte, error) {
-	n := bjson.Number(*v)
+func (v Number) MarshalJSON() ([]byte, error) {
+	n := bjson.Number(v)
 	return json.Marshal(n)
 }

--- a/encoding/json/number.go
+++ b/encoding/json/number.go
@@ -1,0 +1,41 @@
+package json
+
+import (
+	bjson "encoding/json"
+)
+
+type Number struct {
+	bjson.Number
+}
+
+func (n Number) String() string { return n.Number.String() }
+
+// Float64 returns the number as a float64.
+func (n Number) Float64() (float64, error) {
+	return n.Number.Float64()
+}
+
+// Int64 returns the number as an int64.
+func (n Number) Int64() (int64, error) {
+	return n.Number.Int64()
+}
+
+func (v *Number) UnmarshalJSON(b []byte) error {
+	strB := string(b)
+	if strB == "" || strB == "null" {
+		return nil
+	}
+
+	var s bjson.Number
+	err := bjson.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	v.Number = s
+	return nil
+}
+
+func (v *Number) MarshalJSON() ([]byte, error) {
+	return []byte(v.String()), nil
+}

--- a/encoding/json/number_test.go
+++ b/encoding/json/number_test.go
@@ -3,116 +3,113 @@ package json_test
 import (
 	"testing"
 
+	bjson "encoding/json"
+
 	"github.com/bukalapak/ottoman/encoding/json"
 	"github.com/stretchr/testify/assert"
 )
 
+type testCase struct {
+	test               string
+	shouldErrUnmarshal bool
+	strVal             string
+	shouldErrInt       bool
+	intVal             int64
+	floatVal           float64
+	shouldErrFloat     bool
+}
+
+func runTest(t *testing.T, tc testCase, shouldUseOttomanCoder bool) {
+
+	var err error
+	var n json.Number
+
+	if shouldUseOttomanCoder {
+		err = json.Unmarshal([]byte(tc.test), &n)
+	} else {
+		err = n.UnmarshalJSON([]byte(tc.test))
+	}
+
+	if tc.shouldErrUnmarshal {
+		assert.Error(t, err)
+		return
+	}
+
+	var errM error
+	var byteArr []byte
+	if shouldUseOttomanCoder {
+		byteArr, errM = json.Marshal(n)
+	} else {
+		byteArr, errM = bjson.Marshal(n)
+	}
+
+	assert.Nil(t, errM)
+
+	if tc.test == "" || tc.test == "null" { // special condition, will be converted to empty string
+		assert.Equal(t, "", string(byteArr))
+	} else {
+		assert.Equal(t, tc.test, string(byteArr))
+	}
+
+	assert.Equal(t, tc.strVal, n.Number.String())
+
+	actualInt, err := n.Number.Int64()
+	if tc.shouldErrInt {
+		assert.Error(t, err)
+	} else {
+		assert.Nil(t, err)
+		assert.Equal(t, tc.intVal, actualInt)
+	}
+
+	actualFloat, err := n.Number.Float64()
+	if tc.shouldErrFloat {
+		assert.Error(t, err)
+	} else {
+		assert.Nil(t, err)
+		assert.Equal(t, tc.floatVal, actualFloat)
+	}
+
+}
+
+func runTestCases(t *testing.T, tcs []testCase, shouldUseOttomanCoder bool) {
+	for _, test := range tcs {
+		runTest(t, test, shouldUseOttomanCoder)
+	}
+}
+
 func TestNumber_invalid(t *testing.T) {
-	var m json.Number
 
-	x := "lorem"
-	err := m.UnmarshalJSON([]byte(x))
-	assert.NotNil(t, err)
+	var testCases = []testCase{
+		{test: "lorem", shouldErrUnmarshal: true},
+		{test: "1L", shouldErrUnmarshal: true},
+		{test: "12.1012.01", shouldErrUnmarshal: true},
+	}
 
-	x = "1L"
-	err = m.UnmarshalJSON([]byte(x))
-	assert.NotNil(t, err)
+	runTestCases(t, testCases, false)
+	runTestCases(t, testCases, true) // with ottoman decoder
 
-	x = "12.1012.01"
-	err = m.UnmarshalJSON([]byte(x))
-	assert.NotNil(t, err)
 }
 
 func TestNumber_empty_string(t *testing.T) {
-	var m json.Number
 
-	x := ""
-	err := m.UnmarshalJSON([]byte(x))
-	assert.Nil(t, err)
-	assert.Equal(t, "", m.String())
+	var testCases = []testCase{
+		{test: "", shouldErrUnmarshal: false, shouldErrInt: true, shouldErrFloat: true},
+		{test: "null", shouldErrUnmarshal: false, shouldErrInt: true, shouldErrFloat: true},
+	}
 
-	_, err = m.Int64()
-	assert.NotNil(t, err)
+	runTestCases(t, testCases, false)
+	runTestCases(t, testCases, true) // with ottoman decoder
 
-	b, err := m.MarshalJSON()
-	assert.Nil(t, err)
-	assert.Equal(t, x, string(b))
-
-	x = "null"
-	err = m.UnmarshalJSON([]byte(x))
-	assert.Nil(t, err)
-	assert.Equal(t, "", m.String())
-
-	_, err = m.Int64()
-	assert.Error(t, err)
-
-	b, err = m.MarshalJSON()
-	assert.Nil(t, err)
-	assert.Equal(t, "", string(b))
-
-	err = m.UnmarshalJSON([]byte(nil))
-	assert.Nil(t, err)
-	assert.Equal(t, "", m.String())
-
-	_, err = m.Int64()
-	assert.Error(t, err)
-
-}
-
-func TestNumber_null_string(t *testing.T) {
-	var m json.Number
-
-	x := "null"
-	err := m.UnmarshalJSON([]byte(x))
-	assert.Nil(t, err)
-
-	_, err = m.Int64()
-	assert.Error(t, err)
-
-	b, err := m.MarshalJSON()
-	assert.Nil(t, err)
-	assert.Equal(t, "", string(b))
 }
 
 func TestNumber_number_string(t *testing.T) {
-	var m json.Number
 
-	x := "3"
-	err := m.UnmarshalJSON([]byte(x))
-	assert.Nil(t, err)
+	var testCases = []testCase{
+		{test: "3", shouldErrUnmarshal: false, strVal: "3", shouldErrInt: false, intVal: 3, shouldErrFloat: false, floatVal: 3},
+		{test: "1", shouldErrUnmarshal: false, strVal: "1", shouldErrInt: false, intVal: 1, shouldErrFloat: false, floatVal: 1},
+		{test: "3.6", shouldErrUnmarshal: false, strVal: "3.6", shouldErrInt: true, shouldErrFloat: false, floatVal: 3.6},
+	}
 
-	v, err := m.Int64()
-	assert.Nil(t, err)
-	assert.Equal(t, int64(3), v)
-
-	b, err := m.MarshalJSON()
-	assert.Nil(t, err)
-	assert.Equal(t, x, string(b))
-
-	x = "1"
-	err = m.UnmarshalJSON([]byte(x))
-	assert.Nil(t, err)
-
-	v, err = m.Int64()
-	assert.Nil(t, err)
-	assert.Equal(t, int64(1), v)
-
-	b, err = m.MarshalJSON()
-	assert.Nil(t, err)
-	assert.Equal(t, x, string(b))
-
-	x = "3.6"
-	err = m.UnmarshalJSON([]byte(x))
-	assert.Nil(t, err)
-
-	v, err = m.Int64()
-	assert.Error(t, err)
-
-	u, err := m.Float64()
-	assert.Nil(t, err)
-	assert.Equal(t, float64(3.6), u)
-
-	b, err = m.MarshalJSON()
-	assert.Nil(t, err)
-	assert.Equal(t, x, string(b))
+	runTestCases(t, testCases, false)
+	runTestCases(t, testCases, true) // with ottoman decoder
 }

--- a/encoding/json/number_test.go
+++ b/encoding/json/number_test.go
@@ -1,0 +1,118 @@
+package json_test
+
+import (
+	"testing"
+
+	"github.com/bukalapak/ottoman/encoding/json"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNumber_invalid(t *testing.T) {
+	var m json.Number
+
+	x := "lorem"
+	err := m.UnmarshalJSON([]byte(x))
+	assert.NotNil(t, err)
+
+	x = "1L"
+	err = m.UnmarshalJSON([]byte(x))
+	assert.NotNil(t, err)
+
+	x = "12.1012.01"
+	err = m.UnmarshalJSON([]byte(x))
+	assert.NotNil(t, err)
+}
+
+func TestNumber_empty_string(t *testing.T) {
+	var m json.Number
+
+	x := ""
+	err := m.UnmarshalJSON([]byte(x))
+	assert.Nil(t, err)
+	assert.Equal(t, "", m.String())
+
+	_, err = m.Int64()
+	assert.NotNil(t, err)
+
+	b, err := m.MarshalJSON()
+	assert.Nil(t, err)
+	assert.Equal(t, x, string(b))
+
+	x = "null"
+	err = m.UnmarshalJSON([]byte(x))
+	assert.Nil(t, err)
+	assert.Equal(t, "", m.String())
+
+	_, err = m.Int64()
+	assert.Error(t, err)
+
+	b, err = m.MarshalJSON()
+	assert.Nil(t, err)
+	assert.Equal(t, "", string(b))
+
+	err = m.UnmarshalJSON([]byte(nil))
+	assert.Nil(t, err)
+	assert.Equal(t, "", m.String())
+
+	_, err = m.Int64()
+	assert.Error(t, err)
+
+}
+
+func TestNumber_null_string(t *testing.T) {
+	var m json.Number
+
+	x := "null"
+	err := m.UnmarshalJSON([]byte(x))
+	assert.Nil(t, err)
+
+	_, err = m.Int64()
+	assert.Error(t, err)
+
+	b, err := m.MarshalJSON()
+	assert.Nil(t, err)
+	assert.Equal(t, "", string(b))
+}
+
+func TestNumber_number_string(t *testing.T) {
+	var m json.Number
+
+	x := "3"
+	err := m.UnmarshalJSON([]byte(x))
+	assert.Nil(t, err)
+
+	v, err := m.Int64()
+	assert.Nil(t, err)
+	assert.Equal(t, int64(3), v)
+
+	b, err := m.MarshalJSON()
+	assert.Nil(t, err)
+	assert.Equal(t, x, string(b))
+
+	x = "1"
+	err = m.UnmarshalJSON([]byte(x))
+	assert.Nil(t, err)
+
+	v, err = m.Int64()
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), v)
+
+	b, err = m.MarshalJSON()
+	assert.Nil(t, err)
+	assert.Equal(t, x, string(b))
+
+	x = "3.6"
+	err = m.UnmarshalJSON([]byte(x))
+	assert.Nil(t, err)
+
+	v, err = m.Int64()
+	assert.Error(t, err)
+
+	u, err := m.Float64()
+	assert.Nil(t, err)
+	assert.Equal(t, float64(3.6), u)
+
+	b, err = m.MarshalJSON()
+	assert.Nil(t, err)
+	assert.Equal(t, x, string(b))
+}

--- a/encoding/json/number_test.go
+++ b/encoding/json/number_test.go
@@ -63,7 +63,7 @@ func TestCustomJSONNumber(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, x, v)
 
-	ss, err := json.Marshal(&v)
+	ss, err := json.Marshal(v)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedString, strings.TrimSpace(string(ss)))
 }


### PR DESCRIPTION
We discovered that the unmarshal behavior of json.Number changed. On go1.13, whenever empty string umarshaled into json.Number, there won't be any error. On go1.14, the behavior is return error. See https://go-review.googlesource.com/c/go/+/195045/

Summary of changes: create custom unmarshaller for Number.