### PR TITLE
Fix timeout error identification

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -4,7 +4,9 @@ package memcache
 import (
 	"bytes"
 	"compress/zlib"
+	"errors"
 	"io"
+	"net"
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
@@ -225,6 +227,15 @@ func timeoutError(err error) bool {
 		return false
 	}
 
-	_, ok := err.(*memcache.ConnectTimeoutError)
-	return ok
+	err = errors.Unwrap(err)
+	if err == nil {
+		return false
+	}
+
+	nerr, ok := err.(net.Error)
+	if !ok {
+		return false
+	}
+
+	return nerr.Timeout()
 }


### PR DESCRIPTION
Timeout error in memcached call should be like this

```
read tcp 10.90.142.64:43080->10.49.42.100:11212: i/o timeout
```

This error actually is a [net.Error](https://pkg.go.dev/net#Error) wrapped with [OpError](https://pkg.go.dev/net#OpError). This changes will fix this bug